### PR TITLE
feat: 🎸 Add support for using an API token

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,4 +8,4 @@ sources:
 maintainers:
   - name: Simon Garcia
     email: deportivo2005@gmail.com
-version: 0.1.0
+version: 1.1.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,37 @@
 
 TL;DR;
 
-```helm install -name pihole-exporter --namespace pihole ./```
+```
+helm install -name pihole-exporter --namespace pihole ./
+```
+
+Using an auth token:
+```
+helm install \
+  -name pihole-exporter \
+  --namespace pihole \
+  --set secretEnvVars.PIHOLE_APITOKEN=myPiHoleApiToken \
+  ./
+```
+
+Using a password:
+```
+helm install \
+  -name pihole-exporter \
+  --namespace pihole \
+  --set secretEnvVars.PIHOLE_PASSWORD=myPiHolePassword \
+  ./
+```
+
+Setting the hostname with a password:
+```
+helm install \
+  -name pihole-exporter \
+  --namespace pihole \
+  --set secretEnvVars.PIHOLE_PASSWORD=myPiHolePassword \
+  --set extraEnvVars.PIHOLE_HOSTNAME=my.pihole.server \
+  ./
+```
 
 ## Introduction
 
@@ -13,10 +43,11 @@ I have not set a default configuration, please modify the values.yaml file with 
 
 ## Configuration
 
-| Parameter                      | Description                            | Default            |
-| ------------------------------ |:--------------------------------------:| ------------------:|
-| service.port                   | Port for the kubernetes service        | 9617               |
-| extraEnvVars.INTERVAL          | How often to poll pihole stats         | 10s                |
-| extraEnvVars.PIHOLE_HOSTNAME   | Pihole Hostname                        | None               |
-| extraEnvVars.PIHOLE_PASSWORD   | Pihole admin user password             | None               |
-| extraEnvVars.PORT              | Change default webserver port for app  | 9617               |
+| Parameter                     | Description                           | Default |
+| :---------------------------- | :------------------------------------ | ------: |
+| service.port                  | Port for the kubernetes service       |    9617 |
+| extraEnvVars.INTERVAL         | How often to poll pihole stats        |     10s |
+| extraEnvVars.PIHOLE_HOSTNAME  | Pihole Hostname                       |    None |
+| secretEnvVars.PIHOLE_PASSWORD | Pihole admin user password            |    None |
+| secretEnvVars.PIHOLE_APITOKEN | Pihole api token                      |    None |
+| extraEnvVars.PORT             | Change default webserver port for app |    9617 |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
           - name: {{ $key | quote }}
             value: {{ $value | quote }}
           {{- end }}
+          envFrom:
+            - secretRef:
+              name: {{ include "pihole-exporter.fullname" . }}
           ports:
           - name: httpexporter
             containerPort: {{ .Values.service.port }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.secretEnvVars }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pihole-exporter.fullname" . }}
+  labels:
+{{ include "pihole-exporter.labels" . | indent 4 }}
+type: Opaque
+data:
+  {{ if .Values.secretEnvVars.PIHOLE_PASSWORD }}
+  PIHOLE_PASSWORD:  {{ .Values.secretEnvVars.PIHOLE_PASSWORD | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.secretEnvVars.PIHOLE_APITOKEN }}
+  PIHOLE_APITOKEN:  {{ .Values.secretEnvVars.PIHOLE_APITOKEN | b64enc | quote }}
+  {{ end }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -31,12 +31,14 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-extraEnvVars: {
+extraEnvVars:
   INTERVAL: 10s,
   PIHOLE_HOSTNAME: service-name.namespace.svc.cluster.local, #InsertYourValueHere
-  PIHOLE_PASSWORD: password, #InsertYourValueHere
 #  PORT: 8080 #ChangeDefaultWebserverPort
-    }
+
+# secretEnvVars:
+#   PIHOLE_PASSWORD: 
+#   PIHOLE_APITOKEN: 
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
PR for pi-hole-exporter change which adds api token support https://github.com/eko/pihole-exporter/pull/37

This change also modifies how the api token or the password are passed
to kubernetes, it will now use the Secret object provided by kubernetes

BREAKING CHANGE: 🧨 Use of the Secret object will not be backwards compatible with previous
installations