### PR TITLE
Fix indentation on name ref

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-              name: {{ include "pihole-exporter.fullname" . }}
+                name: {{ include "pihole-exporter.fullname" . }}
           ports:
           - name: httpexporter
             containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
Otherwise you get `Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].envFrom[0]): unknown field "name" in io.k8s.api.core.v1.EnvFromSource` on a deploy