### PR TITLE
Update notes

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -16,6 +16,6 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "pihole-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.port }}
+  echo "Test your service with `curl -s http://127.0.0.1:8080/metrics`"
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -33,7 +33,8 @@ ingress:
 
 extraEnvVars:
   INTERVAL: 10s,
-  PIHOLE_HOSTNAME: service-name.namespace.svc.cluster.local, #InsertYourValueHere
+  PIHOLE_HOSTNAME: service-name.namespace.svc.cluster.local #InsertYourValueHere
+#  PIHOLE_PORT: 8080 #Change the port the exporter tries to access your Pihole Service on
 #  PORT: 8080 #ChangeDefaultWebserverPort
 
 # secretEnvVars:


### PR DESCRIPTION
A couple of minor tweaks I used for my local install last week.  

* Adding the PIHOLE_PORT variable into the values.yaml as a hint to folks running on something other than '80'
* Updating the chart notes to use the namespace of the release and the service port 
* There's a trailing comma in the PIHOLE_HOSTNAME var that can cause problems