### PR TITLE
use correct environment var PIHOLE_API_TOKEN

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -39,7 +39,7 @@ extraEnvVars:
 
 # secretEnvVars:
 #   PIHOLE_PASSWORD: 
-#   PIHOLE_APITOKEN: 
+#   PIHOLE_API_TOKEN: 
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
There is a typo in the comment for the Pi-Hole API token.  it should be `PIHOLE_API_TOKEN`.  A couple of issues arise if you leave it is is, mainly missing these metrics:

```
pihole_top_queries
pihole_querytypes
pihole_top_ads
pihole_forward_destinations
```