### PR TITLE
Support the use of an existing pi-hole secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Using an auth token:
 helm install \
   -name pihole-exporter \
   --namespace pihole \
-  --set secretEnvVars.PIHOLE_APITOKEN=myPiHoleApiToken \
+  --set secret.secretEnvVars.PIHOLE_API_TOKEN=myPiHoleApiToken \
   ./
 ```
 
@@ -20,7 +20,17 @@ Using a password:
 helm install \
   -name pihole-exporter \
   --namespace pihole \
-  --set secretEnvVars.PIHOLE_PASSWORD=myPiHolePassword \
+  --set secret.secretEnvVars.PIHOLE_PASSWORD=myPiHolePassword \
+  ./
+```
+
+Using an existing secret in the same namespace:
+```
+helm install \
+  -name pihole-exporter \
+  --namespace pihole \
+  --set secret.generate=false \
+  --set secret.existing.secretName=my-pi-hole-secret \
   ./
 ```
 
@@ -38,16 +48,24 @@ helm install \
 
 This chart deploys the pihole-exporter by eko - https://github.com/eko/pihole-exporter to a kubernetes cluster.
 
-## Notes
-I have not set a default configuration, please modify the values.yaml file with your correct config settings.
-
 ## Configuration
 
-| Parameter                     | Description                           | Default |
-| :---------------------------- | :------------------------------------ | ------: |
-| service.port                  | Port for the kubernetes service       |    9617 |
-| extraEnvVars.INTERVAL         | How often to poll pihole stats        |     10s |
-| extraEnvVars.PIHOLE_HOSTNAME  | Pihole Hostname                       |    None |
-| secretEnvVars.PIHOLE_PASSWORD | Pihole admin user password            |    None |
-| secretEnvVars.PIHOLE_APITOKEN | Pihole api token                      |    None |
-| extraEnvVars.PORT             | Change default webserver port for app |    9617 |
+> The default configuration is very rudimentary, please override values as required for your configuration.
+
+To override the default you can either :
+* Set the individual values as required as part if the helm command (i.e. `--set some.value=MY_VALUE`)
+* Create your own `my-values.yaml` containing your custom values (i.e. `helm install -f my-values.yaml .`)
+* (Least preferred) Modify the `values.yaml` file with your configuration.
+
+| Parameter                            | Description                                                                                 |           Default |
+|:-------------------------------------|:--------------------------------------------------------------------------------------------|------------------:|
+| service.port                         | Port for the kubernetes service                                                             |              9617 |
+| extraEnvVars.INTERVAL                | How often to poll pihole stats                                                              |               10s |
+| extraEnvVars.PIHOLE_HOSTNAME         | Pihole Hostname                                                                             |              None |
+| extraEnvVars.PORT                    | Change default webserver port for app                                                       |              9617 |
+| secret.generate                      | Generate a new secret based on the `secretEnvVars` value/s                                  |              true |
+| secret.secretEnvVars.PIHOLE_PASSWORD | Pihole admin user password                                                                  |              None |
+| secret.secretEnvVars.PIHOLE_APITOKEN | Pihole api token                                                                            |              None |
+| secret.existing.secretName           | The name of an existing secret containing the Pihole credentials                            | my-pi-hole-secret |
+| secret.existing.piHoleCredentialType | The type of piHole credential in the secret, either 'PIHOLE_API_TOKEN' or 'PIHOLE_PASSWORD' |  PIHOLE_API_TOKEN |
+| secret.existing.secretKey            | The key within the secret containing the piHole api token or password                       |  PIHOLE_API_TOKEN |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,10 +34,20 @@ spec:
           - name: {{ $key | quote }}
             value: {{ $value | quote }}
           {{- end }}
-          {{ if .Values.secretEnvVars }}
+          {{ with .Values.secret }}
+          {{- if .generate }}
+          # Use env values from generated secret
           envFrom:
             - secretRef:
-                name: {{ include "pihole-exporter.fullname" . }}
+                name: {{ include "pihole-exporter.fullname" $ }}
+          {{- else }}
+          # Use an existing secret
+          - name: {{ .existing.piHoleCredentialType }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .existing.secretName }}
+                key: {{ .existing.secretKey }}
+          {{- end }}
           {{- end }}
           ports:
           - name: httpexporter

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.secretEnvVars }}
+{{ if .Values.secret.generate }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,10 +7,12 @@ metadata:
 {{ include "pihole-exporter.labels" . | indent 4 }}
 type: Opaque
 data:
-  {{ if .Values.secretEnvVars.PIHOLE_PASSWORD }}
-  PIHOLE_PASSWORD:  {{ .Values.secretEnvVars.PIHOLE_PASSWORD | b64enc | quote }}
-  {{ end }}
-  {{ if .Values.secretEnvVars.PIHOLE_APITOKEN }}
-  PIHOLE_APITOKEN:  {{ .Values.secretEnvVars.PIHOLE_APITOKEN | b64enc | quote }}
-  {{ end }}
+  {{- with .Values.secret.secretEnvVars }}
+  {{- if .PIHOLE_PASSWORD }}
+  PIHOLE_PASSWORD:  {{ .PIHOLE_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- if .PIHOLE_API_TOKEN }}
+  PIHOLE_API_TOKEN:  {{ .PIHOLE_API_TOKEN | b64enc | quote }}
+  {{- end }}
+  {{- end }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -37,9 +37,23 @@ extraEnvVars:
 #  PIHOLE_PORT: 8080 #Change the port the exporter tries to access your Pihole Service on
 #  PORT: 8080 #ChangeDefaultWebserverPort
 
-# secretEnvVars:
-#   PIHOLE_PASSWORD: 
-#   PIHOLE_API_TOKEN: 
+secret:
+  # false - generate a new secret using the value(s) from 'secretEnvVars'
+  # true - use an existing secret within the same namespace, see 'existing' below.
+  generate: true
+  # Used when generating a new secret from either the given pi-hole API token OR password
+  secretEnvVars:
+#   PIHOLE_API_TOKEN: <YOUR_PI_HOLE_API_TOKEN>
+#   PIHOLE_PASSWORD: <YOUR_PI_HOLE_PASSWORD>
+
+  # Details of an existing secret within the same namespace containing the pi-hole API token OR password
+  existing:
+    # The name of the existing secret
+    secretName: my-pi-hole-secret
+    # The type of piHole credential in the secret; use 'PIHOLE_API_TOKEN' or 'PIHOLE_PASSWORD'
+    piHoleCredentialType: PIHOLE_API_TOKEN
+    # The key within the secret containing the piHole api token or password
+    secretKey: PIHOLE_API_TOKEN
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This change covers the ability to use an existing (Kubernetes) secret within that same namespace, as per #12 